### PR TITLE
Fix for dependency screw up from move to redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,15 @@
   },
   "homepage": "https://github.com/in-flux/component-router",
   "peerDependencies": {
-    "react": "^0.13 || ~0.14.0-beta",
-    "flux": "^2.0.3"
+    "react": "^0.13 || ~0.14.0-beta"
   },
   "dependencies": {
     "classnames": "^2.1.3",
     "lodash.isfunction": "^3.0.6",
     "lodash.isnull": "^3.0.0",
-    "lodash.isundefined": "^3.0.1"
+    "lodash.isundefined": "^3.0.1",
+    "lodash.throttle": "^3.0.4",
+    "redux": "^1.0.1"
   },
   "devDependencies": {
     "babel": "^5.8.21",
@@ -71,14 +72,12 @@
     "karma-nyan-reporter": "0.2.2",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-webpack": "^1.7.0",
-    "lodash.throttle": "^3.0.4",
     "mkdirp": "^0.5.1",
     "node-libs-browser": "^0.5.2",
     "phantomjs": "^1.9.18",
     "react-hot-loader": "^1.2.8",
     "react-motion": "^0.2.7",
     "react-swap": "^1.0.7",
-    "redux": "^1.0.1",
     "rimraf": "^2.4.2",
     "style-loader": "^0.12.3",
     "tap-xunit": "^1.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,12 +104,6 @@ var build = {
   resolve: {extensions: ['', '.js']},
   stats: {colors: true},
   externals: {
-    flux: {
-      root: 'Flux',
-      commonjs2: 'flux',
-      commonjs: 'flux',
-      amd: 'flux'
-    },
     react: {
       root: 'React',
       commonjs2: 'react',


### PR DESCRIPTION
My mistake became painfully clear when working on the react-router example :disappointed: 