### PR TITLE
 Remove `pathname` completely, fixes #64 

### DIFF
--- a/src/ActionCreator.js
+++ b/src/ActionCreator.js
@@ -2,10 +2,10 @@ import Constants from './Constants';
 
 
 export default {
-  navigateTo({pathname, query}) {
+  navigateTo({query}) {
     return {
       actionType: Constants.NAVIGATE_TO,
-      payload: {pathname, query}
+      payload: {query}
     };
   },
 

--- a/src/Location/Html4.js
+++ b/src/Location/Html4.js
@@ -30,12 +30,12 @@ const Html4 = React.createClass({
 
 
   getUrl() {
-    if (window.location.hash.substr(0, 2) !== '#/') {
-      return '/';
+    if (window.location.hash.substr(0, 2) !== '#?') {
+      return '?';
     }
-    const {pathname, query} = url.parse(window.location.hash.substr(1), true);
+    const {query} = url.parse(window.location.hash.substr(1), true);
 
-    return url.format({pathname, query});
+    return url.format({query});
   },
 
 
@@ -54,8 +54,7 @@ const Html4 = React.createClass({
 
   onChange() {
     this.setUrl(url.format({
-      query: Store.getCleanQuery(),
-      pathname: Store.getPathname()
+      query: Store.getCleanQuery()
     }));
   },
 

--- a/src/Location/Html5.js
+++ b/src/Location/Html5.js
@@ -30,7 +30,7 @@ const Html5 = React.createClass({
 
 
   getUrl() {
-    return [window.location.pathname, window.location.search].join('');
+    return window.location.search;
   },
 
 
@@ -48,8 +48,7 @@ const Html5 = React.createClass({
 
   onChange() {
     this.setUrl(url.format({
-      query: Store.getCleanQuery(),
-      pathname: Store.getPathname()
+      query: Store.getCleanQuery()
     }));
   },
 

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -7,7 +7,6 @@ import shallowEqual from 'react/lib/shallowEqual';
 
 
 const initialState = {
-  pathname: '/',
   query: {},
   defaultParams: {},
   type: Constants.TYPE_HTML5
@@ -16,15 +15,10 @@ const initialState = {
 
 const changeParams = (state, params) => {
   const newParams = urlUtil.merge({
-    pathname: state.pathname,
     query: state.query
   }, params);
   const newQuery = sortedObject({...state.defaultParams, ...newParams.query});
   const newState = {...state};
-
-  if (newState.pathname !== newParams.pathname) {
-    newState.pathname = newParams.pathname;
-  }
 
   if (!shallowEqual(newQuery, newState.query)) {
     newState.query = newQuery;
@@ -38,7 +32,7 @@ const addDefaultParam = (state, {namespace, value}) => {
   const newState = {...state};
 
   if (!newState.defaultParams.hasOwnProperty(namespace) ||
-      newState.defaultParams[namespace] !== stringValue) {
+    newState.defaultParams[namespace] !== stringValue) {
     newState.defaultParams[namespace] = stringValue;
     newState.query = sortedObject({...newState.defaultParams, ...newState.query});
   }
@@ -67,16 +61,15 @@ const safeParams = params => {
   Object.keys(newQuery).forEach(key => newQuery[key] = `${newQuery[key]}`);
 
   return {
-    pathname: isNull(params.pathname) || isUndefined(params.pathname) ? '/' : params.pathname,
     query: newQuery
   };
 };
 
 const restoreLocation = (state, url, type = Constants.TYPE_HTML5) => {
-  const {pathname: newPathname, query: newQuery} = safeParams(urlUtil.parseHref(url));
+  const {query: newQuery} = safeParams(urlUtil.parseHref(url));
   const updatedParams = changeParams(state, {
-    pathname: newPathname,
-    query: {...state.defaultParams, ...newQuery}});
+    query: {...state.defaultParams, ...newQuery}
+  });
 
   return {...updatedParams, type};
 };

--- a/src/Store.js
+++ b/src/Store.js
@@ -25,10 +25,6 @@ const Store = {
     return this.getState().query;
   },
 
-  getPathname() {
-    return this.getState().pathname;
-  },
-
   getType() {
     return this.getState().type;
   },

--- a/src/Store.js
+++ b/src/Store.js
@@ -3,12 +3,15 @@ import sortedObject from './sortedObject';
 import {createStore} from 'redux';
 import reducer from './Reducer';
 
+
 const Store = {
   ...createStore(reducer),
+
 
   getDefaultParams() {
     return this.getState().defaultParams;
   },
+
 
   getCleanQuery() {
     const cleanQuery = {...this.getState().query};
@@ -21,13 +24,16 @@ const Store = {
     return sortedObject(cleanQuery);
   },
 
+
   getQuery() {
     return this.getState().query;
   },
 
+
   getType() {
     return this.getState().type;
   },
+
 
   addThrottledChangeListener(callback, timeout = 200, options = {leading: false, trailing: true}) {
     const throttledCallback = throttle(callback, timeout, options);

--- a/src/Url.js
+++ b/src/Url.js
@@ -9,7 +9,6 @@ import shallowEqual from 'react/lib/shallowEqual';
 
 const Url = React.createClass({
   propTypes: {
-    pathname: React.PropTypes.string,
     query: React.PropTypes.object,
     children: React.PropTypes.node,
     isActiveClass: React.PropTypes.string,
@@ -27,17 +26,13 @@ const Url = React.createClass({
 
 
   getInitialState() {
-    return {
-      query: Store.getQuery(),
-      pathname: Store.getPathname()
-    };
+    return Store.getQuery();
   },
 
 
   shouldComponentUpdate(newProps, newState) {
     return !shallowEqual(newProps, this.props) || !shallowEqual(newState,
-        this.state) || !shallowEqual(newProps.query,
-        this.props.query) || !shallowEqual(newState.query, this.state.query);
+        this.state) || !shallowEqual(newProps.query, this.props.query);
   },
 
 
@@ -58,18 +53,14 @@ const Url = React.createClass({
 
 
   onChange() {
-    this.setState({
-      query: Store.getQuery(),
-      pathname: Store.getPathname()
-    });
+    this.replaceState(Store.getQuery());
   },
 
 
   render() {
-    const oldParams = this.state;
-    const {query, pathname, isActiveClass, ...props} = this.props;
-    const {href} = urlUtil.merge(oldParams, {query, pathname});
-    const isActive = urlUtil.isActive(oldParams, {query, pathname});
+    const {query, isActiveClass, ...props} = this.props;
+    const {href} = urlUtil.merge({query: this.state}, {query});
+    const isActive = urlUtil.isActive({query: this.state}, {query});
     const linkClasses = classnames(this.props.className, {
       [isActiveClass]: isActive
     });

--- a/src/example/App.js
+++ b/src/example/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {ComponentRouter, LocationHtml4, getDefault, Url} from '..';
+import {ComponentRouter, LocationHtml5, getDefault, Url} from '..';
 import styles from './App.css';
 
 import FooBar from './FooBar/FooBar';
@@ -41,30 +41,12 @@ const Header = React.createClass({
   }
 });
 
-//
-//  const Content = React.createClass({
-//    propTypes: {
-//      componentRouter: React.PropTypes.object
-//    },
-//
-//
-//    render() {
-//      const {Component} = this.props.componentRouter;
-//
-//      return (
-//        <div className={styles.content}>
-//          <Component />
-//        </div>
-//      );
-//    }
-//  });
-
 
 const App = React.createClass({
   render() {
     return (
       <div className={styles.app}>
-        <LocationHtml4 />
+        <LocationHtml5 />
 
         <Header />
 

--- a/src/example/Links/Links.js
+++ b/src/example/Links/Links.js
@@ -4,34 +4,26 @@ import styles from './Links.css';
 
 
 const test = [
-  {pathname: '/test'},
-  {pathname: '/'},
   {query: {x: 1}},
   {query: {x: 100}},
   {query: {y: 2}},
   {query: {y: 200}},
-  {pathname: '/', query: {x: 1}},
-  {pathname: '/', query: {x: 100}},
-  {pathname: '/', query: {y: 1}},
-  {pathname: '/', query: {y: 100}},
-  {pathname: '/test', query: {x: 1}},
-  {pathname: '/test', query: {x: 100}},
-  {pathname: '/test', query: {y: 1}},
-  {pathname: '/test', query: {y: 100}}
+  {query: {x: 1}},
+  {query: {x: 100}},
+  {query: {y: 1}},
+  {query: {y: 100}}
 ];
 
 
 const LinkExample = React.createClass({
   propTypes: {
-    pathname: React.PropTypes.string,
     query: React.PropTypes.object
   },
 
   render() {
-    const pathname = this.props.pathname ? `pathname="${this.props.pathname}"` : '';
     const query = this.props.query ? `query="${JSON.stringify(this.props.query)}"` : '';
 
-    return <p><Url {...this.props}>{`<Url ${pathname} ${query} />`}</Url></p>;
+    return <p><Url {...this.props}>{`<Url ${query} />`}</Url></p>;
   }
 });
 

--- a/src/urlUtil.js
+++ b/src/urlUtil.js
@@ -3,18 +3,17 @@ import sortedObject from './sortedObject';
 
 
 const parseHref = (href) => {
-  const {pathname, query} = url.parse(href, true);
+  const {query} = url.parse(href, true);
 
-  return {pathname, query, href: url.format({pathname, query})};
+  return {query, href: url.format({query})};
 };
 
 
 const merge = (oldParams, newParams) => {
-  const pathname = newParams.pathname || oldParams.pathname;
   const query = sortedObject({...oldParams.query, ...newParams.query});
-  const href = url.format({pathname, query});
+  const href = url.format({query});
 
-  return {pathname, query, href};
+  return {query, href};
 };
 
 

--- a/test/ActionCreator-test.js
+++ b/test/ActionCreator-test.js
@@ -15,11 +15,11 @@ describe('ActionCreator', () => {
 
   it('should return an appropriate NAVIGATE_TO action', () => {
     Constants.NAVIGATE_TO = 'test';
-    const action = ActionCreator.navigateTo({pathname: 'pathname', query: 'query'});
+    const action = ActionCreator.navigateTo({query: 'query'});
 
     expect(action).toEqual({
       actionType: 'test',
-      payload: {pathname: 'pathname', query: 'query'}
+      payload: {query: 'query'}
     });
   });
 

--- a/test/Location/Html4-test.js
+++ b/test/Location/Html4-test.js
@@ -15,7 +15,7 @@ describe('LocationHtml4', () => {
   beforeEach(() => {
     storeUnsubscribe = jasmine.createSpy('storeUnsubscribe');
     Store = jasmine.createSpyObj('Store', [
-      'addThrottledChangeListener', 'dispatch', 'getCleanQuery', 'getPathname']);
+      'addThrottledChangeListener', 'dispatch', 'getCleanQuery']);
     Store.addThrottledChangeListener.and.returnValue(storeUnsubscribe);
     Store.TYPE_HTML4 = 'html4';
 
@@ -84,14 +84,14 @@ describe('LocationHtml4', () => {
     beforeEach(() => html4 = TestUtils.renderIntoDocument(<Html4 />));
 
 
-    it('should return default "/" if no hash present', () => {
-      expect(html4.getUrl()).toEqual('/');
+    it('should return default "?" if no hash present', () => {
+      expect(html4.getUrl()).toEqual('?');
     });
 
 
-    it('should simplify hash url to only pathname and query', () => {
-      w.location.hash = '#/test?x=1#anchor';
-      expect(html4.getUrl()).toEqual('/test?x=1');
+    it('should simplify hash url to only query', () => {
+      w.location.hash = '#?x=1#anchor';
+      expect(html4.getUrl()).toEqual('?x=1');
     });
 
 
@@ -118,8 +118,8 @@ describe('LocationHtml4', () => {
 
 
     it('should not push new state if url is the same', () => {
-      w.location.hash = '#/test?x=1';
-      html4.setUrl('/test?x=1');
+      w.location.hash = '#?x=1';
+      html4.setUrl('?x=1');
       expect(w.history.pushState).not.toHaveBeenCalled();
     });
 
@@ -127,12 +127,12 @@ describe('LocationHtml4', () => {
     it('should restore url when hash updated', () => {
       const onHashChange = w.addEventListener.calls.mostRecent().args[1];
 
-      w.location.hash = '#/test?x=1';
+      w.location.hash = '#?x=1';
       onHashChange();
 
       expect(ActionCreator.restoreLocation).toHaveBeenCalled();
       expect(ActionCreator.restoreLocation).toHaveBeenCalledWith({
-        location: '/test?x=1',
+        location: '?x=1',
         type: Store.TYPE_HTML4
       });
     });
@@ -140,13 +140,12 @@ describe('LocationHtml4', () => {
 
     it('should set url when store updated', () => {
       spyOn(html4, 'setUrl');
-      Store.getPathname.and.returnValue('/test');
       Store.getCleanQuery.and.returnValue({x: 1, y: 2});
       const onChange = Store.addThrottledChangeListener.calls.mostRecent().args[0];
 
       onChange();
       expect(html4.setUrl).toHaveBeenCalled();
-      expect(html4.setUrl).toHaveBeenCalledWith('/test?x=1&y=2');
+      expect(html4.setUrl).toHaveBeenCalledWith('?x=1&y=2');
     });
   });
 });

--- a/test/Location/Html5-test.js
+++ b/test/Location/Html5-test.js
@@ -15,13 +15,13 @@ describe('LocationHtml5', () => {
   beforeEach(() => {
     storeUnsubscribe = jasmine.createSpy('storeUnsubscribe');
     Store = jasmine.createSpyObj('Store', [
-      'addThrottledChangeListener', 'dispatch', 'getCleanQuery', 'getPathname']);
+      'addThrottledChangeListener', 'dispatch', 'getCleanQuery']);
     Store.addThrottledChangeListener.and.returnValue(storeUnsubscribe);
     Store.TYPE_HTML5 = 'html5';
 
     ActionCreator = jasmine.createSpyObj('ActionCreator', ['restoreLocation']);
 
-    w.location = {pathname: '/', search: ''};
+    w.location = {search: ''};
     w.addEventListener = jasmine.createSpy('addEventListener');
     w.removeEventListener = jasmine.createSpy('removeEventListener');
     w.history = jasmine.createSpyObj('history', ['pushState']);
@@ -84,12 +84,11 @@ describe('LocationHtml5', () => {
     beforeEach(() => html5 = TestUtils.renderIntoDocument(<Html5 />));
 
 
-    it('should simplify url to only pathname and query', () => {
+    it('should simplify url to only query', () => {
       w.location.port = 1234;
-      w.location.pathname = '/test';
       w.location.search = '?x=1';
       w.location.hash = '#anchor';
-      expect(html5.getUrl()).toEqual('/test?x=1');
+      expect(html5.getUrl()).toEqual('?x=1');
     });
 
 
@@ -116,15 +115,13 @@ describe('LocationHtml5', () => {
 
 
     it('should not push new state if url is the same', () => {
-      w.location.pathname = '/test';
       w.location.search = '?x=1';
-      html5.setUrl('/test?x=1');
+      html5.setUrl('?x=1');
       expect(w.history.pushState).not.toHaveBeenCalled();
     });
 
 
     it('should restore url when location updated', () => {
-      w.location.pathname = '/test';
       w.location.search = '?x=1';
 
       const onPopstate = w.addEventListener.calls.mostRecent().args[1];
@@ -133,7 +130,7 @@ describe('LocationHtml5', () => {
 
       expect(ActionCreator.restoreLocation).toHaveBeenCalled();
       expect(ActionCreator.restoreLocation).toHaveBeenCalledWith({
-        location: '/test?x=1',
+        location: '?x=1',
         type: Store.TYPE_HTML5
       });
     });
@@ -141,13 +138,12 @@ describe('LocationHtml5', () => {
 
     it('should set url when store updated', () => {
       spyOn(html5, 'setUrl');
-      Store.getPathname.and.returnValue('/test');
       Store.getCleanQuery.and.returnValue({x: 1, y: 2});
       const onChange = Store.addThrottledChangeListener.calls.mostRecent().args[0];
 
       onChange();
       expect(html5.setUrl).toHaveBeenCalled();
-      expect(html5.setUrl).toHaveBeenCalledWith('/test?x=1&y=2');
+      expect(html5.setUrl).toHaveBeenCalledWith('?x=1&y=2');
     });
   });
 });

--- a/test/Reducer-test.js
+++ b/test/Reducer-test.js
@@ -25,12 +25,11 @@ describe('Reducer', () => {
 
 
   describe('Init', () => {
-    it('should initialize with default pathname and query', () => {
+    it('should initialize with default query', () => {
       createReducer();
       const initState = Reducer(undefined, {});
 
       expect(initState.query).toEqual({});
-      expect(initState.pathname).toEqual('/');
     });
 
 
@@ -57,7 +56,6 @@ describe('Reducer', () => {
 
 
     it('should restore location', () => {
-      expect(newState.pathname).toEqual('/hello');
       expect(newState.query).toEqual({world: '123'});
     });
 

--- a/test/Store-test.js
+++ b/test/Store-test.js
@@ -24,7 +24,6 @@ describe('Store', () => {
       Store.getState = jasmine.createSpy('getState')
         .and.returnValue({
           query: {x: '400'},
-          pathname: '/test',
           type: 'HTML6',
           defaultParams: {
             page: 'admin',
@@ -37,13 +36,6 @@ describe('Store', () => {
     describe('getQuery', function () {
       it('should return the query from getState()', function () {
         expect(Store.getQuery()).toEqual({x: '400'});
-      });
-    });
-
-
-    describe('getPathname', function () {
-      it('should return the pathname from getState()', function () {
-        expect(Store.getPathname()).toBe('/test');
       });
     });
 
@@ -94,7 +86,6 @@ describe('Store', () => {
       createStore();
       Store.getState = jasmine.createSpy('getState');
       Store.getState.and.returnValue({
-        pathname: '/',
         query: {x: '1', y: '2'},
         defaultParams: {y: '2'}
       });
@@ -114,7 +105,6 @@ describe('Store', () => {
 
     it('should not remove any keys from query if there are no default params', () => {
       Store.getState.and.returnValue({
-        pathname: '/',
         query: {x: '1', y: '2'},
         defaultParams: {}
       });
@@ -124,7 +114,6 @@ describe('Store', () => {
 
     it('should not remove key from query if value is not equal to default', () => {
       Store.getState.and.returnValue({
-        pathname: '/',
         query: {x: '1', y: '2'},
         defaultParams: {y: '10'}
       });

--- a/test/Url-test.js
+++ b/test/Url-test.js
@@ -13,9 +13,8 @@ describe('Url', () => {
   beforeEach(() => {
     storeUnsubscribe = jasmine.createSpy('storeUnsubscribe');
     Store = jasmine.createSpyObj('Store', [
-      'addThrottledChangeListener', 'dispatch', 'getState', 'getQuery', 'getType', 'getPathname']);
+      'addThrottledChangeListener', 'dispatch', 'getState', 'getQuery', 'getType']);
     Store.getState.and.returnValue({
-      pathname: '/',
       query: {},
       defaultParams: {}
     });
@@ -78,7 +77,6 @@ describe('Url', () => {
     beforeEach(() => {
       urlUtil.merge.and.returnValue({href: '/'});
       Store.getQuery.and.returnValue({x: 1});
-      Store.getPathname.and.returnValue('/test');
 
       div = document.createElement('div');
       url = React.render(<Url />, div);
@@ -97,7 +95,7 @@ describe('Url', () => {
 
 
     it('should set inititial state from Store', () => {
-      expect(url.state).toEqual({pathname: '/test', query: {x: 1}});
+      expect(url.state).toEqual({x: 1});
     });
 
 
@@ -106,7 +104,7 @@ describe('Url', () => {
 
       Store.getQuery.and.returnValue({y: 10});
       onChange();
-      expect(url.state).toEqual({pathname: '/test', query: {y: 10}});
+      expect(url.state).toEqual({y: 10});
     });
   });
 
@@ -117,7 +115,7 @@ describe('Url', () => {
 
     beforeEach(() => {
       urlUtil.merge.and.returnValue({href: '/'});
-      url = TestUtils.renderIntoDocument(<Url pathname="/test" query={{x: 1}} />);
+      url = TestUtils.renderIntoDocument(<Url query={{x: 1}} />);
     });
 
 
@@ -138,7 +136,7 @@ describe('Url', () => {
 
       expect(ActionCreator.navigateTo).toHaveBeenCalled();
       expect(ActionCreator.navigateTo)
-        .toHaveBeenCalledWith(jasmine.objectContaining({pathname: '/test', query: {x: 1}}));
+        .toHaveBeenCalledWith(jasmine.objectContaining({query: {x: 1}}));
     });
   });
 });

--- a/test/Url-test.js
+++ b/test/Url-test.js
@@ -18,6 +18,8 @@ describe('Url', () => {
       query: {},
       defaultParams: {}
     });
+    Store.getQuery.and.returnValue({});
+    Store.getType.and.returnValue('HTML6');
 
     Store.addThrottledChangeListener.and.returnValue(storeUnsubscribe);
     ActionCreator = jasmine.createSpyObj('ActionCreator', ['navigateTo']);

--- a/test/urlUtil-test.js
+++ b/test/urlUtil-test.js
@@ -15,95 +15,63 @@ describe('urlUtil', () => {
 
 
   describe('.parseHref', () => {
-    it('should return pathname, query and href', () => {
+    it('should return query and href', () => {
       expect(urlUtil.parseHref('/')).toEqual({
-        pathname: '/',
         query: {},
-        href: '/'
+        href: ''
       });
     });
 
 
-    it('should take only pathname and query from original href', () => {
+    it('should take only query from original href', () => {
       expect(urlUtil.parseHref('http://test.com/test?x=1#anchor')).toEqual({
-        pathname: '/test',
         query: {x: '1'},
-        href: '/test?x=1'
+        href: '?x=1'
       });
     });
   });
 
 
   describe('.merge', () => {
-    it('should keep pathname', () => {
-      const merged = urlUtil.merge({pathname: '/test'}, {query: {x: 1}});
-
-      expect(merged).toEqual({
-        pathname: '/test',
-        query: {x: 1},
-        href: '/test?x=1'
-      });
-    });
-
-
-    it('should override pathname, but keep query', () => {
-      const merged = urlUtil.merge({pathname: '/test', query: {x: 1}}, {pathname: '/'});
-
-      expect(merged).toEqual({
-        pathname: '/',
-        query: {x: 1},
-        href: '/?x=1'
-      });
-    });
-
-
     it('should append new params to query', () => {
-      const merged = urlUtil.merge({pathname: '/', query: {x: 1}}, {query: {y: 10}});
+      const merged = urlUtil.merge({query: {x: 1}}, {query: {y: 10}});
 
       expect(merged).toEqual({
-        pathname: '/',
         query: {x: 1, y: 10},
-        href: '/?x=1&y=10'
+        href: '?x=1&y=10'
       });
     });
 
 
     it('should update existing params', () => {
-      const merged = urlUtil.merge({pathname: '/', query: {x: 1}}, {query: {x: 2, y: 10}});
+      const merged = urlUtil.merge({query: {x: 1}}, {query: {x: 2, y: 10}});
 
       expect(merged).toEqual({
-        pathname: '/',
         query: {x: 2, y: 10},
-        href: '/?x=2&y=10'
+        href: '?x=2&y=10'
       });
     });
 
 
-    it('should merge query and update pathname', () => {
-      const merged = urlUtil.merge({pathname: '/', query: {x: 1, y: 10}},
-        {pathname: '/test', query: {x: 2, z: 100}});
+    it('should merge query', () => {
+      const merged = urlUtil.merge({query: {x: 1, y: 10}},
+        {query: {x: 2, z: 100}});
 
       expect(merged).toEqual({
-        pathname: '/test',
         query: {x: 2, y: 10, z: 100},
-        href: '/test?x=2&y=10&z=100'
+        href: '?x=2&y=10&z=100'
       });
     });
 
 
     it('should sort query params by name', () => {
-      urlUtil.merge({pathname: '/', query: {x: 1, y: 10}}, {query: {x: 2, z: 100}});
+      urlUtil.merge({query: {x: 1, y: 10}}, {query: {x: 2, z: 100}});
       expect(sorted).toHaveBeenCalledWith({x: 2, y: 10, z: 100});
     });
   });
 
 
   describe('.isActive', () => {
-    it('should be active for mathced pathname', () => {
-      expect(urlUtil.isActive({pathname: '/test'}, {pathname: '/test'})).toBeTruthy();
-    });
-
-
     it('should be active for matched query', () => {
       expect(urlUtil.isActive({query: {x: 1}}, {query: {x: 1}}))
         .toBeTruthy();
@@ -111,19 +79,14 @@ describe('urlUtil', () => {
 
 
     it('should be active for query param value match', () => {
-      expect(urlUtil.isActive({pathname: '/test', query: {x: 1, y: 10}}, {query: {x: 1}}))
+      expect(urlUtil.isActive({query: {x: 1, y: 10}}, {query: {x: 1}}))
         .toBeTruthy();
     });
 
 
     it('should be active for dummy link', () => {
-      expect(urlUtil.isActive({pathname: '/test', query: {x: 1, y: 10}}, {}))
+      expect(urlUtil.isActive({query: {x: 1, y: 10}}, {}))
         .toBeTruthy();
-    });
-
-
-    it('should not be active for different pathname', () => {
-      expect(urlUtil.isActive({pathname: '/test'}, {pathname: '/'})).toBeFalsy();
     });
 
 


### PR DESCRIPTION
@halhenke I found some issues with Reducer. State is passed by reference! Not the state itself, but all its properties (like query). So I fixed it as part of this PR.

There are couple of minor issues left... Like we still need pathname for some situations (with html4 location), but it is not there. And another one if you go from blocks page to quickstart page some items are not deleted from URL. I'll raise those issues separately.

Have a look, maybe you can find any other issue.