### PR TITLE
Batch multiple consequent history operations into a single URL state push

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -32,12 +32,18 @@ const push = history => updated(href => history.pushState({}, href));
 export const location = (createHistory, type) => () => {
   const history = createHistory();
   const historyPush = push(history);
+  let timer;
+
+  const batchedHistoryPush = (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => historyPush(...args), 0);
+  };
 
   const historyUnsubscribe = history.listen(({pathname, search, hash}) => {
     store.dispatch(restoreLocation({pathname, search, hash}, type));
   });
 
-  const storeUnsubscribe = store.subscribe(() => historyPush({
+  const storeUnsubscribe = store.subscribe(() => batchedHistoryPush({
     pathname: store.getState().pathname,
     query: store.getState().cleanQuery,
     hash: store.getState().hash


### PR DESCRIPTION
In the case when you run multiple consequent operations on a store, url is updated every time and history is not correct anymore (back/forward buttons are basically useless)

For example this code before update will change URL 3 times
```js
      store.dispatch(actions.removeParam('from'));
      store.dispatch(actions.removeParam('to'));
      store.dispatch(actions.navigateTo({live: 'true'}));
```

With this update URL will be changed only once.