### PR TITLE
Add wildcard routes support

### DIFF
--- a/example/App/index.js
+++ b/example/App/index.js
@@ -63,6 +63,22 @@ const GlobalLinks = ({routingState}) => (
         onClick={navigateTo({pathname: '/404'})}>/404
       </a>
     </li>
+    <li>
+      <a
+        className="tab"
+        data-active={isActive(routingState, {pathname: '/bar/x/z'})}
+        href={href(routingState, {pathname: '/bar/x/z'})}
+        onClick={navigateTo({pathname: '/bar/x/z'})}>/bar/x/z
+      </a>
+    </li>
+    <li>
+      <a
+        className="tab"
+        data-active={isActive(routingState, {pathname: '/foo/x/z'})}
+        href={href(routingState, {pathname: '/foo/x/z'})}
+        onClick={navigateTo({pathname: '/foo/x/z'})}>/foo/x/z
+      </a>
+    </li>
   </ul>
 );
 GlobalLinks.propTypes = {
@@ -203,8 +219,8 @@ const NotFound = () => (
 
 const routes = {
   '/': Home,
-  '/foo': Foo,
-  '/bar': Bar,
+  '/foo/:*/:something': Foo,
+  '/bar/:*': Bar,
   '/cleanHistory': CleanHistory
 };
 

--- a/example/App/index.js
+++ b/example/App/index.js
@@ -79,6 +79,14 @@ const GlobalLinks = ({routingState}) => (
         onClick={navigateTo({pathname: '/foo/x/z'})}>/foo/x/z
       </a>
     </li>
+    <li>
+      <a
+        className="tab"
+        data-active={isActive(routingState, {pathname: '/foo/x/z/more'})}
+        href={href(routingState, {pathname: '/foo/x/z/more'})}
+        onClick={navigateTo({pathname: '/foo/x/z/more'})}>/foo/x/z/more
+      </a>
+    </li>
   </ul>
 );
 GlobalLinks.propTypes = {
@@ -219,7 +227,9 @@ const NotFound = () => (
 
 const routes = {
   '/': Home,
+  '/foo/:*/:something/more': Foo,
   '/foo/:*/:something': Foo,
+  '/foo/:*': Foo,
   '/bar/:*': Bar,
   '/cleanHistory': CleanHistory
 };

--- a/example/App/index.js
+++ b/example/App/index.js
@@ -225,6 +225,8 @@ const NotFound = () => (
 );
 
 
+// First matching route wins, so they should be ordered
+// from the most specific to the least specific in case of overlap
 const routes = {
   '/': Home,
   '/foo/:*/:something/more': Foo,

--- a/scripts/utils/webpack/dev.config.js
+++ b/scripts/utils/webpack/dev.config.js
@@ -21,7 +21,8 @@ module.exports = {
   ],
   output: {
     filename: 'bundle.js',
-    path: pathTo('dev')
+    path: pathTo('dev'),
+    publicPath: '/'
   },
   plugins: [
     plugins.html

--- a/src/pathname/parse.js
+++ b/src/pathname/parse.js
@@ -15,6 +15,12 @@ export const parseRoute = (route = '/') => {
   }
 
   const parsedRoute = parts.reduce(({regex, params}, part) => {
+    if (part === ':*') {
+      return {
+        regex: regex.concat('(.*)'),
+        params: {...params, [part.substr(1)]: null}
+      };
+    }
     if (part.substr(0, 1) === ':') {
       return {
         regex: regex.concat('/([^/]+)'),


### PR DESCRIPTION
Added special wildcard param ":*", can be followed by named params, or other sub-path, or left as the rightmost param to match all.

First matching route wins, so they should be ordered from the most specific to the least specific in case of overlap


For this list of routes:

```js
[
  '/',
  '/foo/:*/:something/more',
  '/foo/:*/:something',
  '/foo/:*',
  '/bar/:*',
  '/cleanHistory'
]
```

These matches will be found based on URL

### `http://localhost:8080/bar`
```json
{
  "currentRoute": {
    "route": "/bar/:*",
    "regex": "^/bar(.*)$",
    "params": {
      "*": ""
    }
  }
}
```

### `http://localhost:8080/bar/x/z`
```json
  {
    "currentRoute": {
      "route": "/bar/:*",
      "regex": "^/bar(.*)$",
      "params": {
        "*": "/x/z"
      }
    }
  }
```

### `http://localhost:8080/foo/x/z`
```json
{
  "currentRoute": {
    "route": "/foo/:*/:something",
    "regex": "^/foo(.*)/([^/]+)$",
    "params": {
      "*": "/x",
      "something": "z"
    }
  }
}
```

### `http://localhost:8080/foo/x/z/more`
```json
{
  "currentRoute": {
    "route": "/foo/:*/:something/more",
    "regex": "^/foo(.*)/([^/]+)/more$",
    "params": {
      "*": "/x",
      "something": "z"
    }
  }
}
```

