### PR TITLE
Fix trailing slash behaviour

### DIFF
--- a/example/App/index.js
+++ b/example/App/index.js
@@ -87,6 +87,14 @@ const GlobalLinks = ({routingState}) => (
         onClick={navigateTo({pathname: '/foo/x/z/more'})}>/foo/x/z/more
       </a>
     </li>
+    <li>
+      <a
+        className="tab"
+        data-active={isActive(routingState, {pathname: '/foo/'})}
+        href={href(routingState, {pathname: '/foo/'})}
+        onClick={navigateTo({pathname: '/foo/'})}>/foo/
+      </a>
+    </li>
   </ul>
 );
 GlobalLinks.propTypes = {
@@ -128,7 +136,6 @@ class ComponentLinks extends React.Component {
           onClick={navigateTo({query: {component: 'baz'}})}>component: baz
         </a>
       </span>
-
     );
   }
 }
@@ -229,6 +236,7 @@ const NotFound = () => (
 // from the most specific to the least specific in case of overlap
 const routes = {
   '/': Home,
+  '/foo': Foo,
   '/foo/:*/:something/more': Foo,
   '/foo/:*/:something': Foo,
   '/foo/:*': Foo,

--- a/src/pathname/parse.js
+++ b/src/pathname/parse.js
@@ -14,10 +14,18 @@ export const parseRoute = (route = '/') => {
     return defaultRoute;
   }
 
-  const parsedRoute = parts.reduce(({regex, params}, part) => {
+  const parsedRoute = parts.reduce(({regex, params}, part, i) => {
     if (part === ':*') {
+      // if `/:*` is the last part, do not require leading `/`
+      // so `/bar/:*` would match both `/bar` and `/bar/`
+      if (i === parts.length - 1) {
+        return {
+          regex: regex.concat('(.*)'),
+          params: {...params, [part.substr(1)]: null}
+        };
+      }
       return {
-        regex: regex.concat('(.*)'),
+        regex: regex.concat('(/.*)'),
         params: {...params, [part.substr(1)]: null}
       };
     }
@@ -36,7 +44,7 @@ export const parseRoute = (route = '/') => {
 
   return {
     route,
-    regex: `^${parsedRoute.regex}$`,
+    regex: `^${parsedRoute.regex}/*$`,
     params: parsedRoute.params
   };
 };

--- a/test/pathname/match-test.js
+++ b/test/pathname/match-test.js
@@ -1,11 +1,17 @@
 import {test} from 'tape';
 import {matchRoute} from './../../src/pathname/match';
+import {parseRoute} from './../../src/pathname/parse';
 
 
-const routes = {
-  '/dossier': {regex: '^/dossier$', params: {}},
-  '/dossier/:host': {regex: '^/dossier/([^/]+)$', params: {host: null}}
-};
+const routes = [
+  '/dossier',
+  '/dossier/:host',
+  '/foo',
+  '/foo/:*/:something/more',
+  '/foo/:*/:something',
+  '/foo/:*',
+  '/bar/:*'
+].reduce((result, route) => Object.assign(result, {[route]: parseRoute(route)}), {});
 
 
 const matcher = matchRoute(routes);
@@ -48,6 +54,51 @@ test('Utils / router / matchRoute', t => {
     matcher('/dossier/d6bb%3A4fc8%3A86f9%3Add99%3A163d%3A7d86%3Afc64%3A5cec'),
     {...routes['/dossier/:host'], params: {host: 'd6bb:4fc8:86f9:dd99:163d:7d86:fc64:5cec'}},
     'should decode URL params'
+  );
+
+  t.deepEquals(
+    matcher('/bar'),
+    {...routes['/bar/:*'], params: {'*': ''}},
+    '/bar -> /bar/:*'
+  );
+  t.deepEquals(
+    matcher('/bar/'),
+    {...routes['/bar/:*'], params: {'*': '/'}},
+    '/bar/ -> /bar/:*'
+  );
+  t.deepEquals(
+    matcher('/bar/x/z'),
+    {...routes['/bar/:*'], params: {'*': '/x/z'}},
+    '/bar/x/z -> /bar/:*'
+  );
+
+  t.deepEquals(matcher('/foo'), routes['/foo'], '/foo -> /foo');
+  t.deepEquals(matcher('/foo/'), routes['/foo'], '/foo/ -> /foo');
+  t.deepEquals(matcher('/foo//////'), routes['/foo'], '/foo////// -> /foo');
+  t.deepEquals(
+    matcher('/foo/x/z'),
+    {...routes['/foo/:*/:something'], params: {'*': '/x', something: 'z'}},
+    '/foo/x/z -> /foo/:*/:something'
+  );
+  t.deepEquals(
+    matcher('/foo/whatever'),
+    {...routes['/foo/:*'], params: {'*': '/whatever'}},
+    '/foo/whatever -> /foo/:*'
+  );
+  t.deepEquals(
+    matcher('/foo/x/z/more'),
+    {...routes['/foo/:*/:something/more'], params: {'*': '/x', something: 'z'}},
+    '/foo/x/z/more -> /foo/:*/:something/more'
+  );
+  t.deepEquals(
+    matcher('/foo/x/z/more////'),
+    {...routes['/foo/:*/:something/more'], params: {'*': '/x', something: 'z'}},
+    '/foo/x/z/more//// -> /foo/:*/:something/more'
+  );
+  t.deepEquals(
+    matcher('/foo//////x/z/more'),
+    {...routes['/foo/:*/:something/more'], params: {'*': '//////x', something: 'z'}},
+    '/foo//////x/z/more -> /foo/:*/:something/more'
   );
 
   t.end();

--- a/test/pathname/parse-test.js
+++ b/test/pathname/parse-test.js
@@ -17,19 +17,19 @@ test('Utils / router / parseRoute', t => {
 
   t.deepEquals(
     parseRoute('/dossier'),
-    {route: '/dossier', regex: '^/dossier$', params: {}},
+    {route: '/dossier', regex: '^/dossier/*$', params: {}},
     'should parse static route /dossier'
   );
 
   t.deepEquals(
     parseRoute('/some/very/deep/url'),
-    {route: '/some/very/deep/url', regex: '^/some/very/deep/url$', params: {}},
+    {route: '/some/very/deep/url', regex: '^/some/very/deep/url/*$', params: {}},
     'should parse deep static route /some/very/deep/url'
   );
 
   t.deepEquals(
     parseRoute('/dossier/:host'),
-    {route: '/dossier/:host', regex: '^/dossier/([^/]+)$', params: {host: null}},
+    {route: '/dossier/:host', regex: '^/dossier/([^/]+)/*$', params: {host: null}},
     'should parse route with param /dossier/:host'
   );
 
@@ -37,7 +37,7 @@ test('Utils / router / parseRoute', t => {
     parseRoute('/dossier/:host/:somethingElse'),
     {
       route: '/dossier/:host/:somethingElse',
-      regex: '^/dossier/([^/]+)/([^/]+)$',
+      regex: '^/dossier/([^/]+)/([^/]+)/*$',
       params: {host: null, somethingElse: null}
     },
     'should parse route with multiple params /dossier/:host/:somethingElse'
@@ -47,7 +47,7 @@ test('Utils / router / parseRoute', t => {
     parseRoute('/I-am-dashed/:with~tilde/o\\uch'),
     {
       route: '/I-am-dashed/:with~tilde/o\\uch',
-      regex: '^/I-am-dashed/([^/]+)/o\\\\uch$',
+      regex: '^/I-am-dashed/([^/]+)/o\\\\uch/*$',
       params: {'with~tilde': null}
     },
     'should parse route with awkward parts /I-am-dashed/:with~tilde/o\\uch'

--- a/test/pathname/render-test.js
+++ b/test/pathname/render-test.js
@@ -45,5 +45,18 @@ test('Utils / router / renderRoute', t => {
     'should throw on missing param'
   );
 
+  // TODO: make sure we can have symmetric two way parse <-> render, without extra encoding
+  t.equals(
+    renderRoute('/foo/:*/:something/more')({something: 123, '*': '/many/slashes/'}),
+    '/foo/%2Fmany%2Fslashes%2F/123/more',
+    'should render route /foo/:*/:something/more as /foo/%2Fmany%2Fslashes%2F/123/more'
+  );
+
+  t.throws(
+    () => renderRoute('/foo/:*/:something/more')({something: 123}),
+    'Param :* is not specified',
+    'should throw on missing param'
+  );
+
   t.end();
 });


### PR DESCRIPTION
Added special wildcard param ":*", can be followed by named params, or other sub-path, or left as the rightmost param to match all.

First matching route wins, so they should be ordered from the most specific to the least specific in case of overlap


For this list of routes:

```js
[
  '/',
  '/foo',
  '/foo/:*/:something/more',
  '/foo/:*/:something',
  '/foo/:*',
  '/bar/:*',
  '/cleanHistory'
]
```

These matches will be found based on URL

### `http://localhost:8080/bar`
```json
{
  "currentRoute": {
    "route": "/bar/:*",
    "regex": "^/bar(.*)/*$",
    "params": {
      "*": ""
    }
  }
}
```
### `http://localhost:8080/bar/`
```json
{
  "currentRoute": {
    "route": "/bar/:*",
    "regex": "^/bar(.*)/*$",
    "params": {
      "*": ""
    }
  }
}
```
### `http://localhost:8080/bar/x/z`
```json
  {
    "currentRoute": {
      "route": "/bar/:*",
      "regex": "^/bar(.*)/*$",
      "params": {
        "*": "/x/z"
      }
    }
  }
```
### `http://localhost:8080/foo`
```json
{
  "currentRoute": {
    "route": "/foo",
    "regex": "^/foo/*$",
    "params": {}
  }
}
```
### `http://localhost:8080/foo/`
```json
{
  "currentRoute": {
    "route": "/foo",
    "regex": "^/foo/*$",
    "params": {}
  }
}
```
### `http://localhost:8080/foo//////`
```json
{
  "currentRoute": {
    "route": "/foo",
    "regex": "^/foo/*$",
    "params": {}
  }
}
```
### `http://localhost:8080/foo/x/z`
```json
{
  "currentRoute": {
    "route": "/foo/:*/:something",
    "regex": "^/foo(.*)/([^/]+)/*$",
    "params": {
      "*": "/x",
      "something": "z"
    }
  }
}
```
### `http://localhost:8080/foo/whatever`
```json
{
  "currentRoute": {
    "route": "/foo/:*",
    "regex": "^/foo(.*)/*$",
    "params": {
      "*": "/whatever"
    }
  }
}
```
### `http://localhost:8080/foo/x/z/more`
```json
{
  "currentRoute": {
    "route": "/foo/:*/:something/more",
    "regex": "^/foo(.*)/([^/]+)/more/*$",
    "params": {
      "*": "/x",
      "something": "z"
    }
  }
}
```
### `http://localhost:8080/foo/x/z/more////`
```json
{
  "currentRoute": {
    "route": "/foo/:*/:something/more",
    "regex": "^/foo(.*)/([^/]+)/more/*$",
    "params": {
      "*": "/x",
      "something": "z"
    }
  }
}
```
### `http://localhost:8080/foo//////x/z/more`
```json
{
  "currentRoute": {
    "route": "/foo/:*/:something/more",
    "regex": "^/foo(.*)/([^/]+)/more/*$",
    "params": {
      "*": "//////x",
      "something": "z"
    }
  }
}
```

